### PR TITLE
Send signal value to HWSIM_ATTR_SIGNAL

### DIFF
--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -511,7 +511,7 @@ int send_cloned_frame_msg(struct wmediumd *ctx, struct station *dst,
 		    dst->hwaddr) ||
 	    nla_put(msg, HWSIM_ATTR_FRAME, data_len, data) ||
 	    nla_put_u32(msg, HWSIM_ATTR_RX_RATE, 1) ||
-	    nla_put_u32(msg, HWSIM_ATTR_SIGNAL, -50)) {
+	    nla_put_u32(msg, HWSIM_ATTR_SIGNAL, signal)) {
 		w_logf(ctx, LOG_ERR, "%s: Failed to fill a payload\n", __func__);
 		ret = -1;
 		goto out;


### PR DESCRIPTION
wmediumd is able to send the **received signal strength** to the interface (or HWSIM_ATTR_SIGNAL) when HWSIM_ATTR_SIGNAL is equal to _signal_ value. Changes in mac80211_hwsim is not required anymore (as presented in https://www.youtube.com/watch?v=gtaHCpaHBGc) when wmediumd is enabled.